### PR TITLE
test warehouse parameter on connection action

### DIFF
--- a/src/Keboola/DbWriter/Writer/Snowflake.php
+++ b/src/Keboola/DbWriter/Writer/Snowflake.php
@@ -358,7 +358,6 @@ class Snowflake extends Writer implements WriterInterface
                 throw $e;
             }
         }
-
     }
 
     public function generateTmpName($tableName)

--- a/src/Keboola/DbWriter/Writer/Snowflake.php
+++ b/src/Keboola/DbWriter/Writer/Snowflake.php
@@ -335,15 +335,15 @@ class Snowflake extends Writer implements WriterInterface
     {
         $this->execQuery('SELECT current_date;');
 
-        $paramWarehouse = !empty($this->dbParams['warehouse']) ? $this->dbParams['warehouse'] : null;
+        $envWarehouse = !empty($this->dbParams['warehouse']) ? $this->dbParams['warehouse'] : null;
         $defaultWarehouse = $this->getUserDefaultWarehouse();
-        if (!$defaultWarehouse && !$warehouse) {
+        if (!$defaultWarehouse && !$envWarehouse) {
             throw new UserException('Specify "warehouse" parameter');
         }
 
         $warehouse = $defaultWarehouse;
-        if ($paramWarehouse) {
-            $warehouse = $paramWarehouse;
+        if ($envWarehouse) {
+            $warehouse = $envWarehouse;
         }
 
         try {

--- a/tests/Keboola/DbWriter/Writer/SnowflakeTest.php
+++ b/tests/Keboola/DbWriter/Writer/SnowflakeTest.php
@@ -273,7 +273,6 @@ class SnowflakeTest extends BaseTest
         $this->setUserDefaultWarehouse($user, null);
 
         /** @var Snowflake $writer */
-        var_dump($config['parameters']);
         $writer = $this->getWriter($config['parameters']);
         $writer->testConnection();
 


### PR DESCRIPTION
Pokud ma uzivatel nastaveny spatny warehouse, snowflake zarve az pri pokusu o load/unload z tabulky

Protoze ho mame nove jako volitelny parametr, pridal jsem jeho validaci primo do test connection.

![image](https://cloud.githubusercontent.com/assets/1726727/24206104/9b7a4206-0f1d-11e7-98da-93fc73c7b63b.png)
