### PR TITLE
Fix for upgrade to db-wr-common 5

### DIFF
--- a/src/Keboola/DbWriter/Snowflake/Application.php
+++ b/src/Keboola/DbWriter/Snowflake/Application.php
@@ -67,10 +67,8 @@ class Application extends BaseApplication
         $stageTable = $tableConfig;
         $stageTable['dbName'] = $writer->generateTmpName($tableConfig['dbName']);
 
-        $stageTable['temporary'] = true;
-
         $writer->drop($stageTable['dbName']);
-        $writer->create($stageTable);
+        $writer->createStaging($stageTable);
         $writer->writeFromS3($s3info, $stageTable);
 
         // create destination table if not exists

--- a/src/Keboola/DbWriter/Writer/Snowflake.php
+++ b/src/Keboola/DbWriter/Writer/Snowflake.php
@@ -395,7 +395,8 @@ class Snowflake extends Writer implements WriterInterface
 
     public function generateTmpName(string $tableName): string
     {
-        return '__temp_' . str_replace('.', '_', uniqid('wr_db_', true));
+        $tmpId = '_temp_' . uniqid('wr_db_', true);
+        return mb_substr($tableName, 0, 256 - mb_strlen($tmpId)) . $tmpId;
     }
 
     /**

--- a/src/Keboola/DbWriter/Writer/Snowflake.php
+++ b/src/Keboola/DbWriter/Writer/Snowflake.php
@@ -61,7 +61,7 @@ class Snowflake extends Writer implements WriterInterface
         throw new ApplicationException("Method not implemented");
     }
 
-    public function createSnowflakeConnection($dbParams)
+    public function createSnowflakeConnection($dbParams): Connection
     {
         $connection = new Connection($dbParams);
         $connection->query(sprintf("ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = %d", self::STATEMENT_TIMEOUT_IN_SECONDS));

--- a/src/Keboola/DbWriter/Writer/Snowflake.php
+++ b/src/Keboola/DbWriter/Writer/Snowflake.php
@@ -194,7 +194,8 @@ class Snowflake extends Writer implements WriterInterface
             $sqlDefinitions [] = $this->getPrimaryKeySqlDefinition($table['primaryKey']);
         }
 
-        $this->execQuery(sprintf("CREATE TABLE %s (%s);",
+        $this->execQuery(sprintf(
+            "CREATE TABLE %s (%s);",
             $this->quoteIdentifier($table['dbName']),
             implode(', ', $sqlDefinitions)
         ));
@@ -207,7 +208,8 @@ class Snowflake extends Writer implements WriterInterface
             $sqlDefinitions [] = $this->getPrimaryKeySqlDefinition($table['primaryKey']);
         }
 
-        $this->execQuery(sprintf("CREATE TEMPORARY TABLE %s (%s);",
+        $this->execQuery(sprintf(
+            "CREATE TEMPORARY TABLE %s (%s);",
             $this->quoteIdentifier($table['dbName']),
             implode(', ', $sqlDefinitions)
         ));
@@ -470,7 +472,6 @@ class Snowflake extends Writer implements WriterInterface
                 )
             )
         );
-
     }
 
     private function hideCredentialsInQuery($query)

--- a/src/Keboola/DbWriter/Writer/Snowflake.php
+++ b/src/Keboola/DbWriter/Writer/Snowflake.php
@@ -324,11 +324,18 @@ class Snowflake extends Writer implements WriterInterface
     public function tableExists(string $tableName): bool
     {
         $res = $this->db->fetchAll(sprintf(
-            "SELECT *
-            FROM INFORMATION_SCHEMA.TABLES
-            WHERE table_name = '%s'",
-            $tableName
+            "
+                SELECT *
+                FROM INFORMATION_SCHEMA.TABLES
+                WHERE TABLE_NAME = %s
+                AND TABLE_SCHEMA = %s
+                AND TABLE_CATALOG = %s
+            ",
+            $this->quote($tableName),
+            $this->quote($this->dbParams['schema']),
+            $this->quote($this->dbParams['database'])
         ));
+
 
         return !empty($res);
     }

--- a/src/Keboola/DbWriter/Writer/Snowflake.php
+++ b/src/Keboola/DbWriter/Writer/Snowflake.php
@@ -218,16 +218,7 @@ class Snowflake extends Writer implements WriterInterface
         }
 
         if (!empty($table['primaryKey'])) {
-            $writer = $this;
-            $sql .= "PRIMARY KEY (" . implode(
-                ', ',
-                array_map(
-                    function ($primaryColumn) use ($writer) {
-                        return $writer->escape($primaryColumn);
-                    },
-                    $table['primaryKey']
-                )
-            ) . ")";
+            $sql .= $this->getPrimaryKeySqlDefinition($table['primaryKey']);
             $sql .= ',';
         }
 
@@ -444,22 +435,32 @@ class Snowflake extends Writer implements WriterInterface
             return;
         }
 
-        $writer = $this;
         $sql = sprintf(
-            "ALTER TABLE %s ADD PRIMARY KEY(%s);",
+            "ALTER TABLE %s ADD %s;",
             $this->nameWithSchemaEscaped($targetTable),
+            $this->getPrimaryKeySqlDefinition($columns)
+        );
+
+        $this->execQuery($sql);
+    }
+
+    private function getPrimaryKeySqlDefinition(array $primaryColumns): string
+    {
+        $writer = $this;
+
+        return sprintf(
+            "PRIMARY KEY(%s)",
             implode(
                 ', ',
                 array_map(
                     function ($primaryColumn) use ($writer) {
                         return $writer->escape($primaryColumn);
                     },
-                    $columns
+                    $primaryColumns
                 )
             )
         );
 
-        $this->execQuery($sql);
     }
 
     private function hideCredentialsInQuery($query)

--- a/src/Keboola/DbWriter/Writer/Snowflake.php
+++ b/src/Keboola/DbWriter/Writer/Snowflake.php
@@ -182,13 +182,6 @@ class Snowflake extends Writer implements WriterInterface
         return ($q . str_replace("$q", "$q$q", $value) . $q);
     }
 
-    public function isTableValid(array $table, $ignoreExport = false)
-    {
-        // TODO: Implement isTableValid() method.
-
-        return true;
-    }
-
     public function drop(string $tableName): void
     {
         $this->execQuery(sprintf("DROP TABLE IF EXISTS %s;", $this->escape($tableName)));

--- a/src/Keboola/DbWriter/Writer/Snowflake.php
+++ b/src/Keboola/DbWriter/Writer/Snowflake.php
@@ -184,7 +184,7 @@ class Snowflake extends Writer implements WriterInterface
 
     public function drop(string $tableName): void
     {
-        $this->execQuery(sprintf("DROP TABLE IF EXISTS %s;", $this->escape($tableName)));
+        $this->execQuery(sprintf("DROP TABLE IF EXISTS %s;", $this->quoteIdentifier($tableName)));
     }
 
     public function create(array $table): void
@@ -195,7 +195,7 @@ class Snowflake extends Writer implements WriterInterface
         }
 
         $this->execQuery(sprintf("CREATE TABLE %s (%s);",
-            $this->escape($table['dbName']),
+            $this->quoteIdentifier($table['dbName']),
             implode(', ', $sqlDefinitions)
         ));
     }
@@ -208,7 +208,7 @@ class Snowflake extends Writer implements WriterInterface
         }
 
         $this->execQuery(sprintf("CREATE TEMPORARY TABLE %s (%s);",
-            $this->escape($table['dbName']),
+            $this->quoteIdentifier($table['dbName']),
             implode(', ', $sqlDefinitions)
         ));
     }
@@ -334,11 +334,6 @@ class Snowflake extends Writer implements WriterInterface
         throw new ApplicationException("Method not implemented");
     }
 
-    private function escape($str)
-    {
-        return '"' . $str . '"';
-    }
-
     public function getUserDefaultWarehouse()
     {
         $sql = sprintf(
@@ -449,7 +444,7 @@ class Snowflake extends Writer implements WriterInterface
             }
             $sql .= sprintf(
                 "%s %s %s %s,",
-                $this->escape($col['dbName']),
+                $this->quoteIdentifier($col['dbName']),
                 $type,
                 $null,
                 $default
@@ -469,7 +464,7 @@ class Snowflake extends Writer implements WriterInterface
                 ', ',
                 array_map(
                     function ($primaryColumn) use ($writer) {
-                        return $writer->escape($primaryColumn);
+                        return $writer->quoteIdentifier($primaryColumn);
                     },
                     $primaryColumns
                 )

--- a/tests/phpunit/SnowflakeTest.php
+++ b/tests/phpunit/SnowflakeTest.php
@@ -71,15 +71,10 @@ class SnowflakeTest extends BaseTest
           firstname VARCHAR(30) NOT NULL,
           lastname VARCHAR(30) NOT NULL)");
 
-        $this->writer->drop("dropMe");
+        $this->assertTrue($this->writer->tableExists('dropMe'));
 
-        $res = $conn->fetchAll("
-            SELECT *
-            FROM INFORMATION_SCHEMA.TABLES
-            WHERE table_name = 'dropMe'
-        ");
-
-        $this->assertEmpty($res);
+        $this->writer->drop('dropMe');
+        $this->assertFalse($this->writer->tableExists('dropMe'));
     }
 
     public function testCreate()
@@ -90,15 +85,10 @@ class SnowflakeTest extends BaseTest
 
         foreach ($tables as $table) {
             $this->writer->drop($table['dbName']);
+            $this->assertFalse($this->writer->tableExists($table['dbName']));
+
             $this->writer->create($table);
-
-            $res = $conn->fetchAll("
-                SELECT *
-                FROM INFORMATION_SCHEMA.TABLES
-                WHERE table_name = '{$table['dbName']}'
-            ");
-
-            $this->assertEquals($table['dbName'], $res[0]['TABLE_NAME']);
+            $this->assertTrue($this->writer->tableExists($table['dbName']));
         }
     }
 

--- a/tests/phpunit/SnowflakeTest.php
+++ b/tests/phpunit/SnowflakeTest.php
@@ -355,6 +355,14 @@ class SnowflakeTest extends BaseTest
         $this->writer->checkPrimaryKey(['id', 'name'], $tmpTable['dbName']);
     }
 
+    public function testCreateConnection()
+    {
+        $connection = $this->writer->createSnowflakeConnection($this->config['parameters']['db']);
+
+        $result = $connection->fetchAll('SELECT current_date;');
+        $this->assertNotEmpty($result);
+    }
+
     private function setUserDefaultWarehouse($warehouse = null)
     {
         $user = $this->writer->getCurrentUser();

--- a/tests/phpunit/SnowflakeTest.php
+++ b/tests/phpunit/SnowflakeTest.php
@@ -104,6 +104,8 @@ class SnowflakeTest extends BaseTest
         $logger->pushHandler($testHandler);
 
         $writerFactory = new WriterFactory($this->config['parameters']);
+
+        /** @var Snowflake $writer */
         $writer =  $writerFactory->create($logger);
 
         if (!$writer instanceof Snowflake) {

--- a/tests/phpunit/SnowflakeTest.php
+++ b/tests/phpunit/SnowflakeTest.php
@@ -152,7 +152,7 @@ class SnowflakeTest extends BaseTest
     {
         $tables = array_filter(
             $this->config['parameters']['tables'],
-            function ($table) use($incrementalValue) {
+            function ($table) use ($incrementalValue) {
                 return $table['incremental'] === $incrementalValue;
             }
         );
@@ -197,7 +197,7 @@ class SnowflakeTest extends BaseTest
     {
         $tables = array_filter(
             $this->config['parameters']['tables'],
-            function ($table) use($incrementalValue) {
+            function ($table) use ($incrementalValue) {
                 return $table['incremental'] === $incrementalValue;
             }
         );

--- a/tests/phpunit/SnowflakeTest.php
+++ b/tests/phpunit/SnowflakeTest.php
@@ -3,6 +3,7 @@
 namespace Keboola\DbWriter\Snowflake\Tests;
 
 use Keboola\Csv\CsvFile;
+use Keboola\DbWriter\Exception\ApplicationException;
 use Keboola\DbWriter\Exception\UserException;
 use Keboola\DbWriter\Snowflake\Connection;
 use Keboola\DbWriter\Snowflake\Test\S3Loader;
@@ -68,6 +69,13 @@ class SnowflakeTest extends BaseTest
 
         $result = $connection->fetchAll('SELECT current_date;');
         $this->assertNotEmpty($result);
+
+        try {
+            $this->writer->createConnection($this->config['parameters']['db']);
+            $this->fail('Create connection via Common inteface method should fail');
+        } catch (ApplicationException $e) {
+            $this->assertContains('Method not implemented', $e->getMessage());
+        }
     }
 
     public function testGetConnection()
@@ -76,6 +84,13 @@ class SnowflakeTest extends BaseTest
 
         $result = $connection->fetchAll('SELECT current_date;');
         $this->assertNotEmpty($result);
+
+        try {
+            $this->writer->getConnection();
+            $this->fail('Getting connection via Common inteface method should fail');
+        } catch (ApplicationException $e) {
+            $this->assertContains('Method not implemented', $e->getMessage());
+        }
     }
 
     public function testDrop()

--- a/tests/phpunit/SnowflakeTest.php
+++ b/tests/phpunit/SnowflakeTest.php
@@ -106,7 +106,10 @@ class SnowflakeTest extends BaseTest
         $writerFactory = new WriterFactory($this->config['parameters']);
         $writer =  $writerFactory->create($logger);
 
-        $this->assertTrue($writer instanceof Snowflake);
+        if (!$writer instanceof Snowflake) {
+            $this->fail("Writer factory must init Snowflake Writer");
+        }
+
         $this->assertCount(0, $testHandler->getRecords());
 
         $writer->testConnection();

--- a/tests/phpunit/SnowflakeTest.php
+++ b/tests/phpunit/SnowflakeTest.php
@@ -62,6 +62,22 @@ class SnowflakeTest extends BaseTest
         return $this->s3Loader->upload($tableId);
     }
 
+    public function testCreateConnection()
+    {
+        $connection = $this->writer->createSnowflakeConnection($this->config['parameters']['db']);
+
+        $result = $connection->fetchAll('SELECT current_date;');
+        $this->assertNotEmpty($result);
+    }
+
+    public function testGetConnection()
+    {
+        $connection = $this->writer->getSnowflakeConnection();
+
+        $result = $connection->fetchAll('SELECT current_date;');
+        $this->assertNotEmpty($result);
+    }
+
     public function testDrop()
     {
         $conn = $this->writer->getSnowflakeConnection();
@@ -353,14 +369,6 @@ class SnowflakeTest extends BaseTest
         $this->writer->upsert($table, $tmpTable['dbName']);
 
         $this->writer->checkPrimaryKey(['id', 'name'], $tmpTable['dbName']);
-    }
-
-    public function testCreateConnection()
-    {
-        $connection = $this->writer->createSnowflakeConnection($this->config['parameters']['db']);
-
-        $result = $connection->fetchAll('SELECT current_date;');
-        $this->assertNotEmpty($result);
     }
 
     private function setUserDefaultWarehouse($warehouse = null)

--- a/tests/phpunit/SnowflakeTest.php
+++ b/tests/phpunit/SnowflakeTest.php
@@ -97,6 +97,23 @@ class SnowflakeTest extends BaseTest
         $this->assertFalse($this->writer->generateStageName((string) getenv('KBC_RUNID')) === Snowflake::STAGE_NAME);
     }
 
+    public function testTmpName()
+    {
+        $tableName = 'firstTable';
+
+        $tmpName = $this->writer->generateTmpName($tableName);
+        $this->assertRegExp('/' . $tableName . '/ui', $tmpName);
+        $this->assertRegExp('/temp/ui', $tmpName);
+        $this->assertLessThanOrEqual(256, mb_strlen($tmpName));
+
+        $tableName = str_repeat('firstTableWithLongName', 15);
+
+        $this->assertGreaterThanOrEqual(256, mb_strlen($tableName));
+        $tmpName = $this->writer->generateTmpName($tableName);
+        $this->assertRegExp('/temp/ui', $tmpName);
+        $this->assertLessThanOrEqual(256, mb_strlen($tmpName));
+    }
+
     public function testWriteAsync()
     {
         $tables = $this->config['parameters']['tables'];


### PR DESCRIPTION
V mym poslednim PR https://github.com/keboola/db-writer-snowflake/pull/47 byl bug kdy pri incrementalnim zapisu to cilovou tabulku zakladalo jako `temporary`.

Delal jsem to podle ukazky ale prehlidl jsem ze Common writer v4 pouziva `incremental` flag pro temporary tabulku, kdezdo v5 pouziva `temporary`.
V tomhle writeru jsem to nakonec udelal tak ze jsem vytvoril novou metodu `createStaging` ktera zaklada docasnou tabulku. 

Zaroven
- jsem to pokryl v testech
- vyhodil jsem nepouzivane/obsolete metody
- do testu doplnil test vsech public metod `Writer\Snowflake` ktere aplikace pouziva
- taky jsem upravil generovani tmp name pro staging tabulky po vzoru Common writeru

Puvodni PR je sice mergnuty, ale neni nasazeny. Takze zadny problem neni.