### PR TITLE
feat: increase statement timeout

### DIFF
--- a/src/Keboola/DbWriter/Snowflake/Connection.php
+++ b/src/Keboola/DbWriter/Snowflake/Connection.php
@@ -65,7 +65,7 @@ class Connection
         if (isset($options['warehouse'])) {
             $dsn .= ';Warehouse=' . $this->quoteIdentifier($options['warehouse']);
         }
-        $dsn .= ";CLIENT_SESSION_KEEP_ALIVE=TRUE";
+        $dsn .= ';CLIENT_SESSION_KEEP_ALIVE=TRUE';
 
         $attemptNumber = 0;
         do {

--- a/src/Keboola/DbWriter/Snowflake/Connection.php
+++ b/src/Keboola/DbWriter/Snowflake/Connection.php
@@ -65,6 +65,7 @@ class Connection
         if (isset($options['warehouse'])) {
             $dsn .= ';Warehouse=' . $this->quoteIdentifier($options['warehouse']);
         }
+        $dsn .= ";CLIENT_SESSION_KEEP_ALIVE=TRUE";
 
         $attemptNumber = 0;
         do {

--- a/src/Keboola/DbWriter/Writer/Snowflake.php
+++ b/src/Keboola/DbWriter/Writer/Snowflake.php
@@ -13,7 +13,7 @@ use Keboola\DbWriter\WriterInterface;
 class Snowflake extends Writer implements WriterInterface
 {
     public const WRITER = 'Snowflake';
-    private const STATEMENT_TIMEOUT_IN_SECONDS = 3600;
+    private const STATEMENT_TIMEOUT_IN_SECONDS = 10800;
     public const STAGE_NAME = 'db-writer';
 
     private static $allowedTypes = [


### PR DESCRIPTION
zendesk ticket 13316

- increased statement timeout to 3 hours
- added CLIENT_SESSION_KEEP_ALIVE for longer running queries