### PR TITLE
[AJDA-2615] Support size for TIME, DATETIME and TIMESTAMP variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 
 This component writes data to a Snowflake database.
 
+### Column length / precision
+
+The `size` column property is rendered into DDL for the following types:
+
+- `NUMBER`, `DECIMAL`, `NUMERIC` — `(precision, scale)`, e.g. `"size": "38,0"`
+- `CHAR`, `CHARACTER`, `VARCHAR`, `STRING`, `TEXT`, `BINARY` — `(length)`, e.g. `"size": "255"`
+- `TIME`, `DATETIME`, `TIMESTAMP`, `TIMESTAMP_NTZ`, `TIMESTAMP_LTZ`, `TIMESTAMP_TZ` — `(precision)`, an integer 0–9, e.g. `"size": "9"`
+
+For all other types `size` is ignored. Invalid precision values are surfaced by Snowflake at DDL execution time.
+
 ## Example Configuration
 
 ```json

--- a/src/Writer/SnowflakeQueryBuilder.php
+++ b/src/Writer/SnowflakeQueryBuilder.php
@@ -15,6 +15,9 @@ class SnowflakeQueryBuilder extends DefaultQueryBuilder
     private const TYPES_WITH_SIZE = [
         'number', 'decimal', 'numeric',
         'char', 'character', 'varchar', 'string', 'text', 'binary',
+        'time',
+        'datetime',
+        'timestamp', 'timestamp_ntz', 'timestamp_ltz', 'timestamp_tz',
     ];
 
     public function __construct(readonly private SnowflakeDatabaseConfig $databaseConfig)

--- a/tests/phpunit/SnowflakeQueryBuilderTest.php
+++ b/tests/phpunit/SnowflakeQueryBuilderTest.php
@@ -231,6 +231,41 @@ class SnowflakeQueryBuilderTest extends TestCase
             'size' => '100',
             'expectedQuery' => 'CREATE TEMPORARY TABLE "test_table" ("col1" BINARY(100) NOT NULL )',
         ];
+        yield 'time' => [
+            'type' => 'time',
+            'size' => '9',
+            'expectedQuery' => 'CREATE TEMPORARY TABLE "test_table" ("col1" TIME(9) NOT NULL )',
+        ];
+        yield 'datetime' => [
+            'type' => 'datetime',
+            'size' => '6',
+            'expectedQuery' => 'CREATE TEMPORARY TABLE "test_table" ("col1" DATETIME(6) NOT NULL )',
+        ];
+        yield 'timestamp' => [
+            'type' => 'timestamp',
+            'size' => '9',
+            'expectedQuery' => 'CREATE TEMPORARY TABLE "test_table" ("col1" TIMESTAMP(9) NOT NULL )',
+        ];
+        yield 'timestamp_ntz' => [
+            'type' => 'timestamp_ntz',
+            'size' => '9',
+            'expectedQuery' => 'CREATE TEMPORARY TABLE "test_table" ("col1" TIMESTAMP_NTZ(9) NOT NULL )',
+        ];
+        yield 'timestamp_ltz' => [
+            'type' => 'timestamp_ltz',
+            'size' => '9',
+            'expectedQuery' => 'CREATE TEMPORARY TABLE "test_table" ("col1" TIMESTAMP_LTZ(9) NOT NULL )',
+        ];
+        yield 'timestamp_tz' => [
+            'type' => 'timestamp_tz',
+            'size' => '3',
+            'expectedQuery' => 'CREATE TEMPORARY TABLE "test_table" ("col1" TIMESTAMP_TZ(3) NOT NULL )',
+        ];
+        yield 'TIMESTAMP_NTZ uppercase' => [
+            'type' => 'TIMESTAMP_NTZ',
+            'size' => '9',
+            'expectedQuery' => 'CREATE TEMPORARY TABLE "test_table" ("col1" TIMESTAMP_NTZ(9) NOT NULL )',
+        ];
         // Types NOT in TYPES_WITH_SIZE — size not applied
         yield 'int' => [
             'type' => 'int',
@@ -277,6 +312,55 @@ class SnowflakeQueryBuilderTest extends TestCase
             'CREATE TEMPORARY TABLE "test_table" ("col1" VARCHAR NOT NULL )',
             $result,
         );
+    }
+
+    /**
+     * @dataProvider noSizeTimestampDataProvider
+     */
+    public function testCreateQueryStatementTimestampWithoutSize(
+        string $type,
+        string $expectedQuery,
+    ): void {
+        $items = [
+            $this->createItemConfig('col1', $type, null, false, null),
+        ];
+
+        $result = $this->queryBuilder->createQueryStatement(
+            $this->connection,
+            'test_table',
+            true,
+            $items,
+        );
+
+        self::assertSame($expectedQuery, $result);
+    }
+
+    public static function noSizeTimestampDataProvider(): Generator
+    {
+        yield 'time without size' => [
+            'type' => 'time',
+            'expectedQuery' => 'CREATE TEMPORARY TABLE "test_table" ("col1" TIME NOT NULL )',
+        ];
+        yield 'datetime without size' => [
+            'type' => 'datetime',
+            'expectedQuery' => 'CREATE TEMPORARY TABLE "test_table" ("col1" DATETIME NOT NULL )',
+        ];
+        yield 'timestamp without size' => [
+            'type' => 'timestamp',
+            'expectedQuery' => 'CREATE TEMPORARY TABLE "test_table" ("col1" TIMESTAMP NOT NULL )',
+        ];
+        yield 'timestamp_ntz without size' => [
+            'type' => 'timestamp_ntz',
+            'expectedQuery' => 'CREATE TEMPORARY TABLE "test_table" ("col1" TIMESTAMP_NTZ NOT NULL )',
+        ];
+        yield 'timestamp_ltz without size' => [
+            'type' => 'timestamp_ltz',
+            'expectedQuery' => 'CREATE TEMPORARY TABLE "test_table" ("col1" TIMESTAMP_LTZ NOT NULL )',
+        ];
+        yield 'timestamp_tz without size' => [
+            'type' => 'timestamp_tz',
+            'expectedQuery' => 'CREATE TEMPORARY TABLE "test_table" ("col1" TIMESTAMP_TZ NOT NULL )',
+        ];
     }
 
     /**


### PR DESCRIPTION
## Summary

The Snowflake writer's DDL builder did not emit `(precision)` for time/timestamp column types, so even if a user supplied a `size` for `TIMESTAMP_NTZ` etc. it was silently dropped, producing a column with the default precision of 9.

This change extends `SnowflakeQueryBuilder::TYPES_WITH_SIZE` to include `time`, `datetime`, `timestamp`, `timestamp_ntz`, `timestamp_ltz`, and `timestamp_tz`, so configurations like `"size": "3"` are now rendered as `TIMESTAMP_NTZ(3)` in the generated DDL.