### PR TITLE
fix: bump db-writer-config to 0.1.3 to fix size:0 handling

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -535,16 +535,16 @@
         },
         {
             "name": "keboola/db-writer-config",
-            "version": "0.1.2",
+            "version": "0.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/db-writer-config.git",
-                "reference": "1b35f0db5e506fe4067714fe68a2edb31dc9b3eb"
+                "reference": "56984ea2efdb33bba85fc59d7410548f87007209"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/db-writer-config/zipball/1b35f0db5e506fe4067714fe68a2edb31dc9b3eb",
-                "reference": "1b35f0db5e506fe4067714fe68a2edb31dc9b3eb",
+                "url": "https://api.github.com/repos/keboola/db-writer-config/zipball/56984ea2efdb33bba85fc59d7410548f87007209",
+                "reference": "56984ea2efdb33bba85fc59d7410548f87007209",
                 "shasum": ""
             },
             "require": {
@@ -580,9 +580,9 @@
             ],
             "description": "Config definition for database writer component",
             "support": {
-                "source": "https://github.com/keboola/db-writer-config/tree/0.1.2"
+                "source": "https://github.com/keboola/db-writer-config/tree/0.1.3"
             },
-            "time": "2024-09-30T11:23:32+00:00"
+            "time": "2026-06-22T14:14:06+00:00"
         },
         {
             "name": "keboola/php-component",
@@ -5552,5 +5552,5 @@
         "ext-mbstring": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## Summary

Bumps `keboola/db-writer-config` from 0.1.2 to 0.1.3 to pick up the fix for `hasSize()` treating `size: \"0\"` as empty.

**Root cause:** PHP's `empty(\"0\") === true` in `ItemConfig::hasSize()` caused `TIMESTAMP_NTZ(0)` precision to be silently discarded. Snowflake then defaulted to `TIMESTAMP_NTZ(9)`.

**Fix:** [keboola/db-writer-config#4](https://github.com/keboola/db-writer-config/pull/4) replaced `!empty($this->size)` with `$this->size !== null && $this->size !== ''`.

This is a lock-file-only change — the constraint `^0.1` already accepts 0.1.3.

Ref: [SUPPORT-15770](https://keboola.atlassian.net/browse/SUPPORT-15770)

## Release Notes
**Justification, description**

Fix `TIMESTAMP_NTZ(0)` (and other `size: \"0\"` columns) not getting precision applied in DDL. Previously the writer emitted bare `TIMESTAMP_NTZ` which Snowflake resolved to `TIMESTAMP_NTZ(9)`.

**Plans for Customer Communication**

Inform the reporter (SUPPORT-15770) that the fix is deployed.

**Impact Analysis**

Only affects columns explicitly configured with `size: \"0\"`. All other size values (including no size) are unaffected. The fix is in the shared `db-writer-config` library; this PR only bumps the lock file.

**Deployment Plan**

Standard release via CI pipeline.

**Rollback Plan**

Revert the lock file bump.

**Post-Release Support Plan**

N/A"

Link to Devin session: https://app.devin.ai/sessions/9730365ae9324b35a302be6292c4d791
Requested by: @natocTo

[SUPPORT-15770]: https://keboola.atlassian.net/browse/SUPPORT-15770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ