### PR TITLE
fix: preserve size '0' in SnowflakeItemConfig::fromArray()

### DIFF
--- a/src/Configuration/ValueObject/SnowflakeItemConfig.php
+++ b/src/Configuration/ValueObject/SnowflakeItemConfig.php
@@ -27,7 +27,7 @@ readonly class SnowflakeItemConfig extends ItemConfig
             $config['name'],
             $config['dbName'],
             $config['type'],
-            $config['size'] ? (string) $config['size'] : null,
+            $config['size'] !== null && $config['size'] !== '' ? (string) $config['size'] : null,
             $config['nullable'] ?? null,
             $config['default'] ?? null,
             $config['foreignKeyTable'] ?? null,

--- a/src/Configuration/ValueObject/SnowflakeItemConfig.php
+++ b/src/Configuration/ValueObject/SnowflakeItemConfig.php
@@ -27,7 +27,7 @@ readonly class SnowflakeItemConfig extends ItemConfig
             $config['name'],
             $config['dbName'],
             $config['type'],
-            $config['size'] ?? null,
+            $config['size'] !== null && $config['size'] !== '' ? (string) $config['size'] : null,
             $config['nullable'] ?? null,
             $config['default'] ?? null,
             $config['foreignKeyTable'] ?? null,

--- a/src/Configuration/ValueObject/SnowflakeItemConfig.php
+++ b/src/Configuration/ValueObject/SnowflakeItemConfig.php
@@ -27,7 +27,7 @@ readonly class SnowflakeItemConfig extends ItemConfig
             $config['name'],
             $config['dbName'],
             $config['type'],
-            $config['size'] !== null && $config['size'] !== '' ? (string) $config['size'] : null,
+            $config['size'] ?? null,
             $config['nullable'] ?? null,
             $config['default'] ?? null,
             $config['foreignKeyTable'] ?? null,

--- a/tests/phpunit/SnowflakeItemConfigTest.php
+++ b/tests/phpunit/SnowflakeItemConfigTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\DbWriter\Snowflake\Tests;
+
+use Keboola\DbWriter\Configuration\ValueObject\SnowflakeItemConfig;
+use PHPUnit\Framework\TestCase;
+
+class SnowflakeItemConfigTest extends TestCase
+{
+    public function testSizeZeroIsPreserved(): void
+    {
+        $config = [
+            'name' => 'col',
+            'dbName' => 'col',
+            'type' => 'timestamp_ntz',
+            'size' => '0',
+            'nullable' => false,
+        ];
+
+        $itemConfig = SnowflakeItemConfig::fromArray($config);
+
+        self::assertTrue($itemConfig->hasSize());
+        self::assertSame('0', $itemConfig->getSize());
+    }
+
+    public function testSizeNonZeroIsPreserved(): void
+    {
+        $config = [
+            'name' => 'col',
+            'dbName' => 'col',
+            'type' => 'varchar',
+            'size' => '255',
+            'nullable' => true,
+        ];
+
+        $itemConfig = SnowflakeItemConfig::fromArray($config);
+
+        self::assertTrue($itemConfig->hasSize());
+        self::assertSame('255', $itemConfig->getSize());
+    }
+
+    public function testSizeNullMeansNoSize(): void
+    {
+        $config = [
+            'name' => 'col',
+            'dbName' => 'col',
+            'type' => 'int',
+            'size' => null,
+            'nullable' => false,
+        ];
+
+        $itemConfig = SnowflakeItemConfig::fromArray($config);
+
+        self::assertFalse($itemConfig->hasSize());
+    }
+
+    public function testSizeEmptyStringMeansNoSize(): void
+    {
+        $config = [
+            'name' => 'col',
+            'dbName' => 'col',
+            'type' => 'int',
+            'size' => '',
+            'nullable' => false,
+        ];
+
+        $itemConfig = SnowflakeItemConfig::fromArray($config);
+
+        self::assertFalse($itemConfig->hasSize());
+    }
+
+    public function testDefaultZeroIsPreserved(): void
+    {
+        $config = [
+            'name' => 'col',
+            'dbName' => 'col',
+            'type' => 'int',
+            'size' => null,
+            'nullable' => false,
+            'default' => '0',
+        ];
+
+        $itemConfig = SnowflakeItemConfig::fromArray($config);
+
+        self::assertTrue($itemConfig->hasDefault());
+        self::assertSame('0', $itemConfig->getDefault());
+    }
+}


### PR DESCRIPTION
## Summary

`SnowflakeItemConfig::fromArray()` used a truthiness check that discarded `size: "0"`:

```php
// Before (buggy):
$config['size'] ? (string) $config['size'] : null,

// After:
$config['size'] !== null && $config['size'] !== '' ? (string) $config['size'] : null,
```

PHP treats `"0"` as falsy, so the old code converted a valid `size: "0"` to `null` **before** the value ever reached the parent constructor. This made the `db-writer-config` 0.1.3 fix (`hasSize()`) ineffective for this writer — `hasSize()` always saw `null` and returned `false`, preventing `TIMESTAMP_NTZ(0)` from being emitted in DDL.

Note: simple `$config['size'] ?? null` doesn't work here because `size` can arrive as an integer (e.g. from Snowflake DESCRIBE TABLE metadata), and the constructor requires `?string`. The explicit check with `(string)` cast handles all input types correctly.

Added `SnowflakeItemConfigTest` covering `"0"`, `null`, and `""` edge cases for size/default.

## Release Notes
**Justification, description**

Fix `size: "0"` being silently discarded by `SnowflakeItemConfig::fromArray()` due to PHP falsy string handling. This prevented `TIMESTAMP_NTZ(0)` precision from being applied despite the `db-writer-config` 0.1.3 fix.

**Plans for Customer Communication**

N/A — transparent bugfix, no config changes required.

**Impact Analysis**

Only affects DDL generation for columns with `size: "0"`. All other configurations unaffected.

**Deployment Plan**

Standard component release after merge.

**Rollback Plan**

Revert PR, redeploy previous image.

**Post-Release Support Plan**

N/A

Ref: SUPPORT-15770

Link to Devin session: https://app.devin.ai/sessions/9730365ae9324b35a302be6292c4d791
Requested by: @natocTo